### PR TITLE
Removed qti.css refs

### DIFF
--- a/views/js/pciCreator/dev/textReaderInteraction/test/commonRenderer.html
+++ b/views/js/pciCreator/dev/textReaderInteraction/test/commonRenderer.html
@@ -9,7 +9,8 @@
         <script type="text/javascript" src="/tao/views/js/lib/qunit/qunit.js"></script>
 
         <link rel="stylesheet" type="text/css" href="/tao/views/css/tao-main-style.css" />
-        <link rel="stylesheet" type="text/css" href="/taoQtiItem/views/css/qti.css" />
+        <link rel="stylesheet" type="text/css" href="/taoQtiItem/views/css/qti-runner.css" />
+        <link rel="stylesheet" type="text/css" href="/taoQtiItem/views/css/themes/default.css" />
         
         <script  type="text/javascript">
             QUnit.config.autostart = false;


### PR DESCRIPTION
related to https://github.com/oat-sa/extension-tao-itemqti/pull/481

Note:
/pciSamples/views/js/pciCreator/dev/textReaderInteraction/test/commonRenderer.html
fails.
Issue is unrelated to PR, reported in https://oat-sa.atlassian.net/browse/TAO-1799