### PR TITLE
FIX/TAO-7123/TextReader PCI does not render tables correctly

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
 	'label' => 'QTI PCI samples',
 	'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '2.3.4',
+    'version' => '2.3.5',
 	'author' => 'Open Assessment Technologies',
 	'requires' => array(
 	    'qtiItemPci' => '>=1.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -87,6 +87,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.3.2');
         }
 
-        $this->skip('2.3.2', '2.3.4');
+        $this->skip('2.3.2', '2.3.5');
     }
 }

--- a/views/js/pciCreator/dev/textReaderInteraction/runtime/js/renderer.js
+++ b/views/js/pciCreator/dev/textReaderInteraction/runtime/js/renderer.js
@@ -167,6 +167,13 @@ define(
 
                 this.options.$container.trigger('beforerenderpages.' + self.eventNs);
 
+                data.pages.forEach(function(page, i) {
+                    data.pages[i].content.forEach(function(content, y){
+                        console.log("foreach here 123")
+                        data.pages[i].content[y] = data.pages[i].content[y].split("<table >").join('<table class="qti-table" >');
+                    });
+                });
+
                 //render pages template
                 if (self.options.templates.pages) {
                     _.assign(templateData, data, self.getTemplateData(data));

--- a/views/js/pciCreator/dev/textReaderInteraction/runtime/js/renderer.js
+++ b/views/js/pciCreator/dev/textReaderInteraction/runtime/js/renderer.js
@@ -169,7 +169,6 @@ define(
 
                 data.pages.forEach(function(page, i) {
                     data.pages[i].content.forEach(function(content, y){
-                        console.log("foreach here 123")
                         data.pages[i].content[y] = data.pages[i].content[y].split("<table >").join('<table class="qti-table" >');
                     });
                 });


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7123

css class disappears from the tables. I have not yet found where the problem occurs.

I propose this temporary solution. it automatically adds the class to the tables that are on the Text Reader PCI pages
