### PR TITLE
feature/TAO-7629 qunit 2 migration

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
 	'label' => 'QTI PCI samples',
 	'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '2.3.4',
+    'version' => '2.3.5',
 	'author' => 'Open Assessment Technologies',
 	'requires' => array(
 	    'qtiItemPci' => '>=1.1.0',

--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
 	'label' => 'QTI PCI samples',
 	'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '2.3.5',
+    'version' => '2.4.0',
 	'author' => 'Open Assessment Technologies',
 	'requires' => array(
 	    'qtiItemPci' => '>=1.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -87,6 +87,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.3.2');
         }
 
-        $this->skip('2.3.2', '2.3.5');
+        $this->skip('2.3.2', '2.4.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -87,6 +87,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.3.2');
         }
 
-        $this->skip('2.3.2', '2.3.4');
+        $this->skip('2.3.2', '2.3.5');
     }
 }

--- a/views/js/pciCreator/dev/textReaderInteraction/test/test.html
+++ b/views/js/pciCreator/dev/textReaderInteraction/test/test.html
@@ -7,8 +7,8 @@
 
     <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
     <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-    <script type="text/javascript" src="js/lib/require.js"></script>
-    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
     <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="/pciSamples/views/js/pciCreator/dev/textReaderInteraction/"></script>
 
     <script  type="text/javascript">

--- a/views/js/pciCreator/dev/textReaderInteraction/test/test.js
+++ b/views/js/pciCreator/dev/textReaderInteraction/test/test.js
@@ -44,7 +44,7 @@ define([
 
         runner = qtiItemRunner('qti', itemData)
             .on('render', function (){
-                ready
+                ready;
             })
             .on('error', function (error){
                 $('#error-display').html(error);

--- a/views/js/pciCreator/dev/textReaderInteraction/test/test.js
+++ b/views/js/pciCreator/dev/textReaderInteraction/test/test.js
@@ -37,14 +37,14 @@ define([
 
     QUnit.module('Text Reader Interaction');
 
-    QUnit.asyncTest('display and play', function (assert){
-
+    QUnit.test('display and play', function (assert){
+        var ready = assert.async();
         var $container = $('#outside-container');
         assert.equal($container.length, 1, 'the item container exists');
 
         runner = qtiItemRunner('qti', itemData)
             .on('render', function (){
-                QUnit.start();
+                ready
             })
             .on('error', function (error){
                 $('#error-display').html(error);


### PR DESCRIPTION
**task** https://oat-sa.atlassian.net/browse/TAO-7629

 **description** convert all unit tests for frontend part to latest Qunit 2 version. More details - in task.
 
**related PRs** 
https://github.com/oat-sa/extension-tao-xmledit/pull/18
https://github.com/oat-sa/extension-tao-test/pull/273
https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/96
https://github.com/oat-sa/extension-tao-testcenter/pull/118
https://github.com/oat-sa/extension-tao-task-queue/pull/83
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/14
https://github.com/oat-sa/extension-tao-testqti/pull/1446
https://github.com/oat-sa/extension-tao-qtiprint/pull/56
https://github.com/oat-sa/extension-tao-itemqti/pull/1248
https://github.com/oat-sa/extension-tao-proctoring/pull/673
https://github.com/oat-sa/extension-tao-outcomeui/pull/254
https://github.com/oat-sa/extension-tao-item/pull/355
https://github.com/oat-sa/extension-tao-clientdiag/pull/223
https://github.com/oat-sa/extension-tao-booklet/pull/82
https://github.com/oat-sa/extension-tao-blueprints/pull/20
https://github.com/oat-sa/extension-tao-itemqti-pci/pull/147
