### PR TITLE
Fix TAO 5913 typo in text reader PCI

### DIFF
--- a/locales/en-US/messages.po
+++ b/locales/en-US/messages.po
@@ -43,6 +43,9 @@ msgstr ""
 msgid "Navigation."
 msgstr ""
 
+msgid "Next"
+msgstr ""
+
 msgid "Page"
 msgstr ""
 
@@ -52,7 +55,7 @@ msgstr ""
 msgid "Page height (px)."
 msgstr ""
 
-msgid "Previous."
+msgid "Previous"
 msgstr ""
 
 msgid "Right"

--- a/locales/lt-LT/messages.po
+++ b/locales/lt-LT/messages.po
@@ -52,6 +52,9 @@ msgstr "Navigacija"
 msgid "Navigation."
 msgstr "Navigacija."
 
+msgid "Next"
+msgstr "Tęsti"
+
 msgid "Page"
 msgstr "Puslapis"
 
@@ -61,8 +64,8 @@ msgstr "Puslapio aukštis (px)"
 msgid "Page height (px)."
 msgstr "Puslapio aukštis (px)."
 
-msgid "Previous."
-msgstr "Grįžti."
+msgid "Previous"
+msgstr "Grįžti"
 
 msgid "Remove Tooltip"
 msgstr "Ištrinti Patarimą"

--- a/locales/nl-NL/messages.po
+++ b/locales/nl-NL/messages.po
@@ -52,6 +52,9 @@ msgstr "Navigatie"
 msgid "Navigation."
 msgstr "Navigatie."
 
+msgid "Next"
+msgstr "Volgende"
+
 msgid "Page"
 msgstr "Pagina"
 
@@ -61,7 +64,7 @@ msgstr "Pagina hoogte (px)"
 msgid "Page height (px)."
 msgstr "Pagina hoogte (px)."
 
-msgid "Previous."
+msgid "Previous"
 msgstr "Vorige"
 
 msgid "Remove Tooltip"

--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return array(
 	'label' => 'QTI PCI samples',
 	'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '2.5.3',
+    'version' => '2.5.4',
 	'author' => 'Open Assessment Technologies',
 	'requires' => array(
 	    'qtiItemPci' => '>=1.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -104,6 +104,9 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.5.3');
         }
 
-        $this->skip('2.5.3', '2.5.4');
+        if ($this->isVersion('2.5.3')) {
+            call_user_func(new RegisterPciTextReader(), ['0.8.5']);
+            $this->setVersion('2.5.4');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -103,5 +103,7 @@ class Updater extends \common_ext_ExtensionUpdater
             call_user_func(new RegisterPciTextReader(), ['0.8.4']);
             $this->setVersion('2.5.3');
         }
+
+        $this->skip('2.5.3', '2.5.4');
     }
 }

--- a/views/js/pciCreator/dev/textReaderInteraction/creator/tpl/propertiesForm.tpl
+++ b/views/js/pciCreator/dev/textReaderInteraction/creator/tpl/propertiesForm.tpl
@@ -48,11 +48,11 @@
     <span class="icon-help tooltipstered" data-tooltip="~ .tooltip-content:first" data-tooltip-theme="info"></span>
     <div class="tooltip-content">{{__ 'Button labels.'}}</div>
     <label class="smaller-prompt">
-        {{__ 'Previous.'}}
+        {{__ 'Previous'}}
         <input name="buttonLabelsPrev" type="text" value="{{buttonLabels.prev}}">
     </label>
     <label class="smaller-prompt">
-        {{__ 'Previous.'}}
+        {{__ 'Next'}}
         <input name="buttonLabelsNext" type="text" value="{{buttonLabels.next}}">
     </label>
 </div>

--- a/views/js/pciCreator/dev/textReaderInteraction/pciCreator.json
+++ b/views/js/pciCreator/dev/textReaderInteraction/pciCreator.json
@@ -2,7 +2,7 @@
     "typeIdentifier": "textReaderInteraction",
     "label": "Text reader",
     "description": "The Paging widget combines a scrolling widget with additional paging controls.",
-    "version": "0.8.4",
+    "version": "0.8.5",
     "author": "Aleh Hutnikau",
     "email": "contact@taotesting.com",
     "tags": [


### PR DESCRIPTION
**Related to:**
https://oat-sa.atlassian.net/browse/TAO-5913

**Description:**
'Previous' is pointed twice. Should be 'Next' instead of second 'Previous'.

**How to check:**
Create item with Text reader PCI.