### PR TITLE
fix: restore OAT TextReaderInteraction

### DIFF
--- a/migrations/Version202103160949554106_pciSamples.php
+++ b/migrations/Version202103160949554106_pciSamples.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace oat\pciSamples\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
+use oat\qtiItemPci\model\IMSPciModel;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
 use Doctrine\Migrations\Exception\IrreversibleMigration;
-use oat\qtiItemPci\model\PciModel;
 use oat\pciSamples\scripts\install\RegisterPciTextReaderIMS;
 
 /**
@@ -15,7 +15,6 @@ use oat\pciSamples\scripts\install\RegisterPciTextReaderIMS;
  */
 final class Version202103160949554106_pciSamples extends AbstractMigration
 {
-
     public function getDescription(): string
     {
         return 'Convert Text Reader interaction to IMS compliant';
@@ -23,7 +22,7 @@ final class Version202103160949554106_pciSamples extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $registry = (new PciModel())->getRegistry();
+        $registry = (new IMSPciModel())->getRegistry();
         if ($registry->has('textReaderInteraction')) {
             /** @noinspection PhpUnhandledExceptionInspection */
             $registry->removeAllVersions('textReaderInteraction');
@@ -41,7 +40,10 @@ final class Version202103160949554106_pciSamples extends AbstractMigration
     public function down(Schema $schema): void
     {
         throw new IrreversibleMigration(
-            'In order to undo this migration, please revert the client-side changes and run ' . RegisterPciTextReaderIMS::class
+            sprintf(
+                'In order to undo this migration, please revert the client-side changes and run %s',
+                RegisterPciTextReaderIMS::class
+            )
         );
     }
 }

--- a/migrations/Version202110280904504106_pciSamples.php
+++ b/migrations/Version202110280904504106_pciSamples.php
@@ -6,16 +6,15 @@ namespace oat\pciSamples\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\Exception\IrreversibleMigration;
-use oat\tao\scripts\tools\migrations\AbstractMigration;
 use oat\pciSamples\scripts\install\RegisterPciTextReaderIMS;
-use oat\qtiItemPci\model\PciModel;
+use oat\qtiItemPci\model\IMSPciModel;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
 final class Version202110280904504106_pciSamples extends AbstractMigration
 {
-
     public function getDescription(): string
     {
         return 'Add basic keyboard navigation to the TextReaderInteraction';
@@ -23,7 +22,7 @@ final class Version202110280904504106_pciSamples extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $registry = (new PciModel())->getRegistry();
+        $registry = (new IMSPciModel())->getRegistry();
         if ($registry->has('textReaderInteraction')) {
             $registry->removeAllVersions('textReaderInteraction');
         }
@@ -38,8 +37,11 @@ final class Version202110280904504106_pciSamples extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-         throw new IrreversibleMigration('In order to undo this migration, please revert the client-side changes and run ' . RegisterPciTextReaderIMS::class
+        throw new IrreversibleMigration(
+            sprintf(
+                'In order to undo this migration, please revert the client-side changes and run %s',
+                RegisterPciTextReaderIMS::class
+            )
         );
-
     }
 }

--- a/migrations/Version202201111538504106_pciSamples.php
+++ b/migrations/Version202201111538504106_pciSamples.php
@@ -6,16 +6,15 @@ namespace oat\pciSamples\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\Exception\IrreversibleMigration;
+use oat\qtiItemPci\model\IMSPciModel;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
 use oat\pciSamples\scripts\install\RegisterPciTextReaderIMS;
-use oat\qtiItemPci\model\PciModel;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
 final class Version202201111538504106_pciSamples extends AbstractMigration
 {
-
     public function getDescription(): string
     {
         return 'Fix text reader PCI destroy lifecycle';
@@ -23,7 +22,7 @@ final class Version202201111538504106_pciSamples extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $registry = (new PciModel())->getRegistry();
+        $registry = (new IMSPciModel())->getRegistry();
         if ($registry->has('textReaderInteraction')) {
             $registry->removeAllVersions('textReaderInteraction');
         }
@@ -34,6 +33,11 @@ final class Version202201111538504106_pciSamples extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        throw new IrreversibleMigration('In order to undo this migration, please revert the client-side changes and run ' . RegisterPciTextReaderIMS::class);
+        throw new IrreversibleMigration(
+            sprintf(
+                'In order to undo this migration, please revert the client-side changes and run %s',
+                RegisterPciTextReaderIMS::class
+            )
+        );
     }
 }

--- a/migrations/Version202203161157144106_pciSamples.php
+++ b/migrations/Version202203161157144106_pciSamples.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\pciSamples\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+use oat\pciSamples\scripts\install\RegisterPciTextReaderIMS;
+use oat\pciSamples\scripts\install\RegisterPciTextReaderOAT;
+use oat\qtiItemPci\model\IMSPciModel;
+use oat\qtiItemPci\model\PciModel;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoQtiItem\model\portableElement\action\RegisterPortableElement;
+use oat\taoQtiItem\model\portableElement\model\PortableElementModel;
+
+final class Version202203161157144106_pciSamples extends AbstractMigration
+{
+    private const RESTORED_PORTABLE_ELEMENT_IDENTIFIER = 'textReaderInteraction';
+    private const RESTORED_OAT_PORTABLE_ELEMENT_VERSION = '0.9.0';
+    private const RESTORED_IMS_PORTABLE_ELEMENT_VERSION = '1.1.1';
+
+    public function getDescription(): string
+    {
+        return sprintf(
+            'Restore PciModel of `%s` versions `%s`',
+            self::RESTORED_PORTABLE_ELEMENT_IDENTIFIER,
+            implode(
+                ', ',
+                [self::RESTORED_OAT_PORTABLE_ELEMENT_VERSION, self::RESTORED_IMS_PORTABLE_ELEMENT_VERSION]
+            )
+        );
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->restoreInteraction(
+            new PciModel(),
+            new RegisterPciTextReaderOAT(),
+            self::RESTORED_OAT_PORTABLE_ELEMENT_VERSION
+        );
+        $this->restoreInteraction(
+            new IMSPciModel(),
+            new RegisterPciTextReaderIMS(),
+            self::RESTORED_IMS_PORTABLE_ELEMENT_VERSION
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new IrreversibleMigration();
+    }
+
+    private function restoreInteraction(
+        PortableElementModel $model,
+        RegisterPortableElement $registerPortableElement,
+        string $version
+    ): void {
+        $registry = $model->getRegistry();
+        if ($registry->has('textReaderInteraction')) {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            $registry->removeAllVersions('textReaderInteraction');
+        }
+
+        $this->addReport(
+            $this->propagate($registerPortableElement)([$version])
+        );
+    }
+}


### PR DESCRIPTION
# [OATSD-1726](https://oat-sa.atlassian.net/browse/OATSD-1726)

## Summary 
Changed TextReader migrations by usage of specific registries, add migration with restartion lates major versions

## how to test 
* install latest release of extension
* try to export items or tests with OAT text reader
* switch on current branch
* update tao
* try export again test or item should be exported 