### PR TITLE
fix: upgrade textreaderinteraction PCIs when Item import

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,39 +27,39 @@ use oat\pciSamples\scripts\install\RegisterUpgardeTextReaderInteractionEvent;
 
 return array(
     'name' => 'pciSamples',
-	'label' => 'QTI PCI samples',
-	'description' => '',
+    'label' => 'QTI PCI samples',
+    'description' => '',
     'license' => 'GPL-2.0',
-	'author' => 'Open Assessment Technologies',
-	'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#pciSamplesManager',
+    'author' => 'Open Assessment Technologies',
+    'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#pciSamplesManager',
     'acl' => array(
-        array('grant', 'http://www.tao.lu/Ontologies/generis.rdf#pciSamplesManager', array('ext'=>'pciSamples')),
+        array('grant', 'http://www.tao.lu/Ontologies/generis.rdf#pciSamplesManager', array('ext' => 'pciSamples')),
     ),
     'install' => array(
-        'php'	=> array(
-			RegisterPciTextReaderOAT::class,
-			RegisterPciTextReaderIMS::class,
+        'php'   => array(
+            RegisterPciTextReaderOAT::class,
+            RegisterPciTextReaderIMS::class,
             RegisterUpgardeTextReaderInteractionEvent::class,
-		)
+        )
     ),
     'update' => 'oat\\pciSamples\\scripts\\update\\Updater',
     'uninstall' => array(
     ),
     'autoload' => array (
         'psr-4' => array(
-            'oat\\pciSamples\\' => dirname(__FILE__).DIRECTORY_SEPARATOR
+            'oat\\pciSamples\\' => dirname(__FILE__) . DIRECTORY_SEPARATOR
         )
     ),
     'routes' => array(
         '/pciSamples' => 'oat\\pciSamples\\controller'
     ),
-	'constants' => array(
-	    # views directory
-	    "DIR_VIEWS" => dirname(__FILE__).DIRECTORY_SEPARATOR."views".DIRECTORY_SEPARATOR,
+    'constants' => array(
+        # views directory
+        "DIR_VIEWS" => dirname(__FILE__) . DIRECTORY_SEPARATOR . "views" . DIRECTORY_SEPARATOR,
 
-		#BASE URL (usually the domain root)
-		'BASE_URL' => ROOT_URL.'pciSamples/',
-	),
+        #BASE URL (usually the domain root)
+        'BASE_URL' => ROOT_URL . 'pciSamples/',
+    ),
     'containerServiceProviders' => [
         UpgradeProcessServiceProvider::class,
     ],

--- a/manifest.php
+++ b/manifest.php
@@ -22,6 +22,7 @@
 use oat\pciSamples\model\ServiceProvider\UpgradeProcessServiceProvider;
 use oat\pciSamples\scripts\install\RegisterPciTextReaderIMS;
 use oat\pciSamples\scripts\install\RegisterPciTextReaderOAT;
+use oat\pciSamples\scripts\install\RegisterUpgardeTextReaderInteractionEvent;
 
 return array(
     'name' => 'pciSamples',
@@ -36,7 +37,8 @@ return array(
     'install' => array(
         'php'	=> array(
 			RegisterPciTextReaderOAT::class,
-			RegisterPciTextReaderIMS::class
+			RegisterPciTextReaderIMS::class,
+            RegisterUpgardeTextReaderInteractionEvent::class,
 		)
     ),
     'update' => 'oat\\pciSamples\\scripts\\update\\Updater',

--- a/migrations/Version202301100820384106_pciSamples.php
+++ b/migrations/Version202301100820384106_pciSamples.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\pciSamples\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\oatbox\event\EventManager;
+use oat\taoQtiItem\model\event\ItemImported;
+use oat\pciSamples\model\event\UpgardeTextReaderInteractionListener;
+
+final class Version202301100820384106_pciSamples extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Register UpgardeTextReaderInteractionListener events';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+
+        $eventManager->attach(
+            ItemImported::class,
+            [UpgardeTextReaderInteractionListener::class, 'whenItemImport']
+        );
+
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+
+        $eventManager->detach(
+            ItemImported::class,
+            [UpgardeTextReaderInteractionListener::class, 'whenItemImport']
+        );
+
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+}

--- a/migrations/Version202301100820384106_pciSamples.php
+++ b/migrations/Version202301100820384106_pciSamples.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
 declare(strict_types=1);
 
 namespace oat\pciSamples\migrations;

--- a/model/event/UpgardeTextReaderInteractionListener.php
+++ b/model/event/UpgardeTextReaderInteractionListener.php
@@ -27,13 +27,22 @@ use oat\oatbox\service\ConfigurableService;
 use oat\taoQtiItem\model\event\ItemImported;
 use oat\pciSamples\model\LegacyPciHelper\Task\UpgradeTextReaderInteractionTask;
 
+/**
+ * Listener for ItemImported event
+ */
 class UpgardeTextReaderInteractionListener extends ConfigurableService
 {
-
+    /**
+     * Call UpgradeTextReaderInteractionTask when ItemImported event happens
+     * @param ItemImported $event
+     * @return null
+     */
     public function whenItemImport(ItemImported $event): void
     {
         $upgradeTextReaderInteraction = new UpgradeTextReaderInteractionTask();
         $upgradeTextReaderInteraction->setServiceLocator($this->getServiceLocator());
-        $upgradeTextReaderInteraction(['itemUri' => $event->getRdfItem()->getUri()]);
+        $upgradeTextReaderInteraction(
+            ['itemUri' => $event->getRdfItem()->getUri()]
+        );
     }
 }

--- a/model/event/UpgardeTextReaderInteractionListener.php
+++ b/model/event/UpgardeTextReaderInteractionListener.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\pciSamples\model\event;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\taoQtiItem\model\event\ItemImported;
+use oat\pciSamples\model\LegacyPciHelper\Task\UpgradeTextReaderInteractionTask;
+
+class UpgardeTextReaderInteractionListener extends ConfigurableService
+{
+
+    public function whenItemImport(ItemImported $event): void
+    {
+        $upgradeTextReaderInteraction = new UpgradeTextReaderInteractionTask();
+        $upgradeTextReaderInteraction->setServiceLocator($this->getServiceLocator());
+        $upgradeTextReaderInteraction(['itemUri' => $event->getRdfItem()->getUri()]);
+    }
+}

--- a/model/event/UpgardeTextReaderInteractionListener.php
+++ b/model/event/UpgardeTextReaderInteractionListener.php
@@ -37,7 +37,7 @@ class UpgardeTextReaderInteractionListener extends ConfigurableService
     /**
      * Call UpgradeTextReaderInteractionTask when ItemImported event happens
      * @param ItemImported $event
-     * @return null
+     * @return void
      */
     public function whenItemImport(ItemImported $event): void
     {
@@ -56,7 +56,7 @@ class UpgardeTextReaderInteractionListener extends ConfigurableService
         } catch (Exception $exception) {
             $this->logError(
                 sprintf(
-                    "chinnu-- Upgrade TextReaderInteraction task failed with this message: %s",
+                    "Upgrade TextReaderInteraction task failed with this message: %s",
                     $exception->getMessage()
                 )
             );

--- a/scripts/install/RegisterUpgardeTextReaderInteractionEvent.php
+++ b/scripts/install/RegisterUpgardeTextReaderInteractionEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\pciSamples\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\taoQtiItem\model\event\ItemImported;
+use oat\pciSamples\model\event\UpgardeTextReaderInteractionListener;
+
+/**
+ * Register a listener for ItemImported event
+ */
+class RegisterUpgardeTextReaderInteractionEvent extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $this->registerEvent(
+            ItemImported::class,
+            [UpgardeTextReaderInteractionListener::class, 'whenItemImport']
+        );
+    }
+}


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/LSI-1594

This PR focus on fixing `textreaderinteraction` PCIs with Legacy items during Item import.
The pciSample repository already has the file`pciSamples/model/LegacyPciHelper/Task/UpgradeTextReaderInteractionTask` to handle such items.
So my aim is to invoke this class when Item/Test import happens. 
For that, I have created an event to listen to ItemImported event.


Related to https://oat-sa.atlassian.net/browse/LSI-1594