### PR TITLE
Fix/ADF-1734/Missing manifest registrations

### DIFF
--- a/views/js/pciCreator/ims/textReaderInteraction/imsPciCreator.json
+++ b/views/js/pciCreator/ims/textReaderInteraction/imsPciCreator.json
@@ -25,7 +25,11 @@
         },
         "libraries" : [],
         "src" : [
-            "./runtime/textReaderInteraction.js"
+            "./runtime/textReaderInteraction.js",
+            "./runtime/js/renderer.js",
+            "./runtime/js/tabs.js",
+            "./runtime/css/jquery.qtip.css",
+            "./runtime/css/textReaderInteraction.css"
         ]
     },
     "creator" : {


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1734

### Summary

Add the missing registration for the PCI that prevent from using hot reload

### Details

The hot reload relies on the manifest to select and copy the files to the registry

### How to test
- Follow the instruction from this article
- Open an item for authoring and add a textReader
