### PR TITLE
fix: INF-343 correct QUnit test discovery paths for v3.9.7.1

### DIFF
--- a/views/build/grunt/test.js
+++ b/views/build/grunt/test.js
@@ -5,8 +5,8 @@ module.exports = function(grunt) {
     var testUrl     = 'http://127.0.0.1:' + grunt.option('testPort');
     var root        = grunt.option('root');
 
-    var testRunners = root + '/pciSamples/views/js/test/**/test.html';
-    var testFiles = root + '/pciSamples/views/js/test/**/test.js';
+    var testRunners = root + '/pciSamples/views/js/pciCreator/**/test.html';
+    var testFiles = root + '/pciSamples/views/js/pciCreator/**/test.js';
 
     //extract unit tests
     var extractTests = function extractTests(){


### PR DESCRIPTION
**Backport:**
- [fix] [INF-343](https://oat-sa.atlassian.net/browse/INF-343) Correct pciSamples QUnit grunt globs so FE CI discovers tests under `views/js/pciCreator/**`

Related: empty `pcisamplestest` suite caused flaky Puppeteer `Target closed` in tao-community CI ([#770](https://github.com/oat-sa/tao-community/pull/770)).

Target release branch: `release-3.9.7.1`
Target release tag: `v3.9.7.1`

[INF-343]: https://oat-sa.atlassian.net/browse/INF-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ