### PR TITLE
fix: INF-343 correct pciSamples QUnit test discovery paths

### DIFF
--- a/views/build/grunt/test.js
+++ b/views/build/grunt/test.js
@@ -5,8 +5,8 @@ module.exports = function(grunt) {
     var testUrl     = 'http://127.0.0.1:' + grunt.option('testPort');
     var root        = grunt.option('root');
 
-    var testRunners = root + '/pciSamples/views/js/test/**/test.html';
-    var testFiles = root + '/pciSamples/views/js/test/**/test.js';
+    var testRunners = root + '/pciSamples/views/js/pciCreator/**/test.html';
+    var testFiles = root + '/pciSamples/views/js/pciCreator/**/test.js';
 
     //extract unit tests
     var extractTests = function extractTests(){


### PR DESCRIPTION
**Fix:**
- [fix] [INF-343](https://oat-sa.atlassian.net/browse/INF-343) Correct pciSamples QUnit grunt globs so FE CI discovers tests under `views/js/pciCreator/**`

Related: empty `pcisamplestest` suite caused flaky Puppeteer `Target closed` in tao-community CI ([#770](https://github.com/oat-sa/tao-community/pull/770)).

Target branch: `develop` (auto-release via oat-github-bot)

Notes:
- Points globs from `views/js/test/**` to `views/js/pciCreator/**`
- No bundle rebuild (grunt config only)
- Backport line for Feb community remains on [#189](https://github.com/oat-sa/extension-pcisample/pull/189) → `v3.9.7.1`

Verification:
- `composer validate --no-check-publish`
- `git diff --check`
- Glob matches existing `pciCreator/**/test.html` runners

[INF-343]: https://oat-sa.atlassian.net/browse/INF-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test discovery to ensure the appropriate test pages and files are included in validation.
  * No direct changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->